### PR TITLE
Better error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# JetBrains IDE project files
+/.idea

--- a/app.js
+++ b/app.js
@@ -6,7 +6,6 @@ const compression = require("compression")
 const helmet = require("helmet")
 const config = require("./config.json")
 const MongoClient = require("mongodb")
-const error = {error: "No results found"}
 const app = express()
 
 const home  = require("./routes/v1-home")
@@ -39,12 +38,27 @@ app.use("/v1/parts", parts)
 
 // 404 Error Handler
 app.use((req, res) => {
-  res.status(404).end(JSON.stringify(error, null, 2))
+  res.status(404)
+  res.json({
+    error: "No results found"
+  })
+})
+
+// generic error handler - must have 4 parameters
+// eslint-disable-next-line no-unused-vars
+app.use((err, req, res, next) => {
+  res.status(500)
+  res.json({
+    error: "Internal Server Error"
+  })
 })
 
 // Mongo Connection + Server Start
 MongoClient.connect(config.url, (err, database) => {
-  if (err) return console.log(err)
+  if (err) {
+    console.log(err)
+    process.exit(1)
+  }
   global.db = database
   
   app.set("port", (process.env.PORT || 5000))

--- a/routes/v1-home.js
+++ b/routes/v1-home.js
@@ -4,9 +4,11 @@ const express = require("express")
 const v1 = express.Router()
 
 // Returns API Info
-v1.get("/", (req, res) => {
+v1.get("/", (req, res, next) => {
   global.db.collection("home").find({},{"_id": 0 }).toArray((err, doc) => {
-    if (err) return console.log(err)
+    if (err) {
+      return next(err)
+    }
     res.json(doc[0])
   })
 })

--- a/routes/v1-home.js
+++ b/routes/v1-home.js
@@ -7,7 +7,7 @@ const v1 = express.Router()
 v1.get("/", (req, res) => {
   global.db.collection("home").find({},{"_id": 0 }).toArray((err, doc) => {
     if (err) return console.log(err)
-    res.end(JSON.stringify(doc[0], null, 2))
+    res.json(doc[0])
   })
 })
 

--- a/routes/v1-info.js
+++ b/routes/v1-info.js
@@ -4,9 +4,11 @@ const express = require("express")
 const v1 = express.Router()
 
 // Returns company info
-v1.get("/", (req, res) => {
+v1.get("/", (req, res, next) => {
   global.db.collection("info").find({},{"_id": 0 }).toArray((err, doc) => {
-    if (err) return console.log(err)
+    if (err) {
+      return next(err)
+    }
     res.json(doc[0])
   })
 })

--- a/routes/v1-info.js
+++ b/routes/v1-info.js
@@ -7,7 +7,7 @@ const v1 = express.Router()
 v1.get("/", (req, res) => {
   global.db.collection("info").find({},{"_id": 0 }).toArray((err, doc) => {
     if (err) return console.log(err)
-    res.end(JSON.stringify(doc[0], null, 2))
+    res.json(doc[0])
   })
 })
 

--- a/routes/v1-launches.js
+++ b/routes/v1-launches.js
@@ -9,7 +9,7 @@ v1.get("/latest", (req, res) => {
   global.db.collection("launch").find({},{"_id": 0 }).sort({"flight_number": -1}).limit(1)
     .toArray((err, doc) => {
       if (err) return console.log(err)
-      res.end(JSON.stringify(doc, null, 2))
+      res.json(doc)
     })
 })
 
@@ -22,34 +22,26 @@ v1.get("/", (req, res) => {
   if (year) {
     global.db.collection("launch").find({"launch_year": `${year}`}, {"_id": 0 }).sort({"flight_number": -1})
       .toArray((err, doc) => {
-        if (doc.length == 0) {
-          res.status(200).end(JSON.stringify(error, null, 2))
-        }
-        res.end(JSON.stringify(doc, null, 2))
+        res.json(doc)
       })
   } else if (start && final) {
     global.db.collection("launch").find({ "launch_date_utc": {"$gte": `${start}T00:00:00Z`, "$lte": `${final}T00:00:00Z`}}, {"_id": 0 })
       .sort({"flight_number": 1})
       .toArray((err, doc) => {
         if (doc.length == 0) {
-          res.status(200).end(JSON.stringify(error, null, 2))
-        }
-        res.end(JSON.stringify(doc, null, 2))
+        res.json(doc)
       })
   } else if (site) {
     global.db.collection("launch").find({ "launch_site.site_id": `${site}`}, {"_id": 0 })
       .sort({"flight_number": 1})
       .toArray((err, doc) => {
-        if (doc.length == 0) {
-          res.status(200).end(JSON.stringify(error, null, 2))
-        }
-        res.end(JSON.stringify(doc, null, 2))
+        res.json(doc)
       })
   } else {
     global.db.collection("launch").find({},{"_id": 0 }).sort({"flight_number": 1})
       .toArray((err, doc) => {
         if (err) return console.log(err)
-        res.end(JSON.stringify(doc, null, 2))
+        res.json(doc)
       })
   }
 })
@@ -60,10 +52,7 @@ v1.get("/cores/:core", (req, res) => {
   global.db.collection("launch").find({"core_serial": `${core}`},{"_id": 0}).sort({"core_serial": 1})
     .toArray((err, doc) => {
       if (err) return console.log(err)
-      if (doc.length == 0) {
-        res.status(200).end(JSON.stringify(error, null, 2))
-      }
-      res.end(JSON.stringify(doc, null, 2))
+      res.json(doc)
     })
 })
 
@@ -73,10 +62,7 @@ v1.get("/caps/:cap", (req, res) => {
   global.db.collection("launch").find({"cap_serial": `${cap}`},{"_id": 0}).sort({"capsule_serial": 1})
     .toArray((err, doc) => {
       if (err) return console.log(err)
-      if (doc.length == 0) {
-        res.status(200).end(JSON.stringify(error, null, 2))
-      }
-      res.end(JSON.stringify(doc, null, 2))
+      res.json(doc)
     })
 })
 
@@ -85,7 +71,7 @@ v1.get("/asds", (req, res) => {
   global.db.collection("launch").find({"landing_type": "ASDS"},{"_id": 0}).sort({"flight_number": 1})
     .toArray((err, doc) => {
       if (err) return console.log(err)
-      res.end(JSON.stringify(doc, null, 2))
+      res.json(doc)
     })
 })
 
@@ -94,7 +80,7 @@ v1.get("/rtls", (req, res) => {
   global.db.collection("launch").find({"landing_type": "RTLS"},{"_id": 0}).sort({"flight_number": 1})
     .toArray((err, doc) => {
       if (err) return console.log(err)
-      res.end(JSON.stringify(doc, null, 2))
+      res.json(doc)
     })
 })
 

--- a/routes/v1-launches.js
+++ b/routes/v1-launches.js
@@ -2,19 +2,20 @@
 
 const express = require("express")
 const v1 = express.Router()
-const error = {error: "No results found"}
 
 // Get most recent launch
-v1.get("/latest", (req, res) => {
+v1.get("/latest", (req, res, next) => {
   global.db.collection("launch").find({},{"_id": 0 }).sort({"flight_number": -1}).limit(1)
     .toArray((err, doc) => {
-      if (err) return console.log(err)
+      if (err) {
+        return next(err)
+      }
       res.json(doc)
     })
 })
 
 // All launches by date, year, or default to all launches
-v1.get("/", (req, res) => {
+v1.get("/", (req, res, next) => {
   const year = req.query.year
   const start = req.query.start
   const final = req.query.final
@@ -28,7 +29,6 @@ v1.get("/", (req, res) => {
     global.db.collection("launch").find({ "launch_date_utc": {"$gte": `${start}T00:00:00Z`, "$lte": `${final}T00:00:00Z`}}, {"_id": 0 })
       .sort({"flight_number": 1})
       .toArray((err, doc) => {
-        if (doc.length == 0) {
         res.json(doc)
       })
   } else if (site) {
@@ -40,46 +40,56 @@ v1.get("/", (req, res) => {
   } else {
     global.db.collection("launch").find({},{"_id": 0 }).sort({"flight_number": 1})
       .toArray((err, doc) => {
-        if (err) return console.log(err)
+        if (err) {
+          return next(err)
+        }
         res.json(doc)
       })
   }
 })
 
 // Returns launches by core serial #
-v1.get("/cores/:core", (req, res) => {
+v1.get("/cores/:core", (req, res, next) => {
   const core = req.params.core
   global.db.collection("launch").find({"core_serial": `${core}`},{"_id": 0}).sort({"core_serial": 1})
     .toArray((err, doc) => {
-      if (err) return console.log(err)
+      if (err) {
+        return next(err)
+      }
       res.json(doc)
     })
 })
 
 // Returns launches by capsule serial #
-v1.get("/caps/:cap", (req, res) => {
+v1.get("/caps/:cap", (req, res, next) => {
   const cap = req.params.cap
   global.db.collection("launch").find({"cap_serial": `${cap}`},{"_id": 0}).sort({"capsule_serial": 1})
     .toArray((err, doc) => {
-      if (err) return console.log(err)
+      if (err) {
+        return next(err)
+      }
       res.json(doc)
     })
 })
 
 // Returns all ASDS launches
-v1.get("/asds", (req, res) => {
+v1.get("/asds", (req, res, next) => {
   global.db.collection("launch").find({"landing_type": "ASDS"},{"_id": 0}).sort({"flight_number": 1})
     .toArray((err, doc) => {
-      if (err) return console.log(err)
+      if (err) {
+        return next(err)
+      }
       res.json(doc)
     })
 })
 
 // Returns all RTLS launches
-v1.get("/rtls", (req, res) => {
+v1.get("/rtls", (req, res, next) => {
   global.db.collection("launch").find({"landing_type": "RTLS"},{"_id": 0}).sort({"flight_number": 1})
     .toArray((err, doc) => {
-      if (err) return console.log(err)
+      if (err) {
+        return next(err)
+      }
       res.json(doc)
     })
 })

--- a/routes/v1-launchpad.js
+++ b/routes/v1-launchpad.js
@@ -7,7 +7,7 @@ const error = {error: "No results found"}
 // Get all launchpads
 v1.get("/", (req, res) => {
   global.db.collection("launchpad").find({},{"_id": 0 }).toArray((err, doc) => {
-    res.end(JSON.stringify(doc, null, 2))
+    res.json(doc)
   })
 })
 
@@ -16,9 +16,10 @@ v1.get("/:pad", (req, res) => {
   const id = req.params.pad
   global.db.collection("launchpad").find({"id": `${id}`}, {"_id": 0 }).toArray((err, doc) => {
     if (doc.length == 0) {
-      res.status(200).end(JSON.stringify(error, null, 2))
+      res.status(404)
+      return res.json(error)
     }
-    res.end(JSON.stringify(doc[0], null, 2))
+    res.json(doc[0])
   })
 })
 

--- a/routes/v1-parts.js
+++ b/routes/v1-parts.js
@@ -5,46 +5,48 @@ const v1 = express.Router()
 const error = {error: "No results found"}
 
 // Returns all capsule information
-v1.get("/caps", (req, res) => {
+v1.get("/caps", (req, res, next) => {
   global.db.collection("capsule").find({},{"_id": 0}).sort({"capsule_serial": 1})
     .toArray((err, doc) => {
-      if (err) return console.log(err)
-      res.end(JSON.stringify(doc, null, 2))
+      if (err) return next(err)
+      res.json(doc)
     })
 })
 
 // Returns capsule info by serial #
-v1.get("/caps/:cap", (req, res) => {
+v1.get("/caps/:cap", (req, res, next) => {
   const cap = req.params.cap
   global.db.collection("capsule").find({"capsule_serial": `${cap}`},{"_id": 0}).sort({"capsule_serial": 1})
     .toArray((err, doc) => {
-      if (err) return console.log(err)
+      if (err) return next(err)
       if (doc.length == 0) {
-        res.status(200).end(JSON.stringify(error, null, 2))
+        res.status(404)
+        return res.json(error)
       }
-      res.end(JSON.stringify(doc[0], null, 2))
+      res.json(doc[0])
     })
 })
 
 // Returns all core information
-v1.get("/cores", (req, res) => {
+v1.get("/cores", (req, res, next) => {
   global.db.collection("core").find({},{"_id": 0}).sort({"core_serial": 1})
     .toArray((err, doc) => {
-      if (err) return console.log(err)
-      res.end(JSON.stringify(doc, null, 2))
+      if (err) return next(err)
+      res.json(doc)
     })
 })
 
 // Returns core info by serial #
-v1.get("/cores/:core", (req, res) => {
+v1.get("/cores/:core", (req, res, next) => {
   const core = req.params.core
   global.db.collection("core").find({"core_serial": `${core}`},{"_id": 0}).sort({"core_serial": 1})
     .toArray((err, doc) => {
-      if (err) return console.log(err)
+      if (err) return next(err)
       if (doc.length == 0) {
-        res.status(200).end(JSON.stringify(error, null, 2))
+        res.status(404)
+        return res.json(error)
       }
-      res.end(JSON.stringify(doc[0], null, 2))
+      res.json(doc[0])
     })
 })
 

--- a/routes/v1-parts.js
+++ b/routes/v1-parts.js
@@ -8,7 +8,9 @@ const error = {error: "No results found"}
 v1.get("/caps", (req, res, next) => {
   global.db.collection("capsule").find({},{"_id": 0}).sort({"capsule_serial": 1})
     .toArray((err, doc) => {
-      if (err) return next(err)
+      if (err) {
+        return next(err)
+      }
       res.json(doc)
     })
 })
@@ -18,7 +20,9 @@ v1.get("/caps/:cap", (req, res, next) => {
   const cap = req.params.cap
   global.db.collection("capsule").find({"capsule_serial": `${cap}`},{"_id": 0}).sort({"capsule_serial": 1})
     .toArray((err, doc) => {
-      if (err) return next(err)
+      if (err) {
+        return next(err)
+      }
       if (doc.length == 0) {
         res.status(404)
         return res.json(error)
@@ -31,7 +35,9 @@ v1.get("/caps/:cap", (req, res, next) => {
 v1.get("/cores", (req, res, next) => {
   global.db.collection("core").find({},{"_id": 0}).sort({"core_serial": 1})
     .toArray((err, doc) => {
-      if (err) return next(err)
+      if (err) {
+        return next(err)
+      }
       res.json(doc)
     })
 })
@@ -41,7 +47,9 @@ v1.get("/cores/:core", (req, res, next) => {
   const core = req.params.core
   global.db.collection("core").find({"core_serial": `${core}`},{"_id": 0}).sort({"core_serial": 1})
     .toArray((err, doc) => {
-      if (err) return next(err)
+      if (err) {
+        return next(err)
+      }
       if (doc.length == 0) {
         res.status(404)
         return res.json(error)

--- a/routes/v1-upcoming.js
+++ b/routes/v1-upcoming.js
@@ -5,32 +5,26 @@ const v1 = express.Router()
 const error = {error: "No results found"}
 
 // Upcoming launches by date, year, or all
-v1.get("/", (req, res) => {
+v1.get("/", (req, res, next) => {
   const year = req.query.year
   const start = req.query.start
   const final = req.query.final
   if (year) {
     global.db.collection("upcoming").find({"launch_year": `${year}`}, {"_id": 0 }).sort({"flight_number": -1})
       .toArray((err, doc) => {
-        if (doc.length == 0) {
-          res.status(200).end(JSON.stringify(error, null, 2))
-        }
-        res.end(JSON.stringify(doc, null, 2))
+        res.json(doc)
       })
   } else if (start && final) {
     global.db.collection("upcoming").find({ "launch_date_utc": {"$gte": `${start}T00:00:00Z`, "$lte": `${final}T00:00:00Z`}}, {"_id": 0 })
       .sort({"flight_number": 1})
       .toArray((err, doc) => {
-        if (doc.length == 0) {
-          res.status(200).end(JSON.stringify(error, null, 2))
-        }
-        res.end(JSON.stringify(doc, null, 2))
+        res.json(doc)
       })
   } else {
     global.db.collection("upcoming").find({},{"_id": 0 }).sort({"flight_number": 1})
       .toArray((err, doc) => {
-        if (err) return console.log(err)
-        res.end(JSON.stringify(doc, null, 2))
+        if (err) return next(err)
+        res.json(doc)
       })
   }
 })

--- a/routes/v1-upcoming.js
+++ b/routes/v1-upcoming.js
@@ -2,7 +2,6 @@
 
 const express = require("express")
 const v1 = express.Router()
-const error = {error: "No results found"}
 
 // Upcoming launches by date, year, or all
 v1.get("/", (req, res, next) => {
@@ -23,7 +22,9 @@ v1.get("/", (req, res, next) => {
   } else {
     global.db.collection("upcoming").find({},{"_id": 0 }).sort({"flight_number": 1})
       .toArray((err, doc) => {
-        if (err) return next(err)
+        if (err) {
+          return next(err)
+        }
         res.json(doc)
       })
   }

--- a/routes/v1-vehicles.js
+++ b/routes/v1-vehicles.js
@@ -6,7 +6,9 @@ const v1 = express.Router()
 // Returns all vehicle info
 v1.get("/", (req, res, next) => {
   global.db.collection("vehicle").find({},{"_id": 0 }).toArray((err, doc) => {
-    if (err) return next(err)
+    if (err) {
+      return next(err)
+    }
     res.json(doc)
   })
 })
@@ -14,7 +16,9 @@ v1.get("/", (req, res, next) => {
 // Returns Falcon 1 info
 v1.get("/falcon1", (req, res, next) => {
   global.db.collection("vehicle").find({"id": "falcon1"},{"_id": 0 }).toArray((err, doc) => {
-    if (err) return next(err)
+    if (err) {
+      return next(err)
+    }
     res.json(doc[0])
   })
 })
@@ -22,7 +26,9 @@ v1.get("/falcon1", (req, res, next) => {
 // Returns Falcon 9 info
 v1.get("/falcon9", (req, res, next) => {
   global.db.collection("vehicle").find({"id": "falcon9"},{"_id": 0 }).toArray((err, doc) => {
-    if (err) return next(err)
+    if (err) {
+      return next(err)
+    }
     res.json(doc[0])
   })
 })
@@ -30,7 +36,9 @@ v1.get("/falcon9", (req, res, next) => {
 // Returns Falcon Heavy info
 v1.get("/falconheavy", (req, res, next) => {
   global.db.collection("vehicle").find({"id": "falcon_heavy"},{"_id": 0 }).toArray((err, doc) => {
-    if (err) return next(err)
+    if (err) {
+      return next(err)
+    }
     res.json(doc[0])
   })
 })
@@ -38,7 +46,9 @@ v1.get("/falconheavy", (req, res, next) => {
 // Returns Dragon info
 v1.get("/dragon", (req, res, next) => {
   global.db.collection("vehicle").find({"id": "dragon"},{"_id": 0 }).toArray((err, doc) => {
-    if (err) return next(err)
+    if (err) {
+      return next(err)
+    }
     res.json(doc[0])
   })
 })

--- a/routes/v1-vehicles.js
+++ b/routes/v1-vehicles.js
@@ -4,42 +4,42 @@ const express = require("express")
 const v1 = express.Router()
 
 // Returns all vehicle info
-v1.get("/", (req, res) => {
+v1.get("/", (req, res, next) => {
   global.db.collection("vehicle").find({},{"_id": 0 }).toArray((err, doc) => {
-    if (err) return console.log(err)
-    res.end(JSON.stringify(doc, null, 2))
+    if (err) return next(err)
+    res.json(doc)
   })
 })
 
 // Returns Falcon 1 info
-v1.get("/falcon1", (req, res) => {
+v1.get("/falcon1", (req, res, next) => {
   global.db.collection("vehicle").find({"id": "falcon1"},{"_id": 0 }).toArray((err, doc) => {
-    if (err) return console.log(err)
-    res.end(JSON.stringify(doc[0], null, 2))
+    if (err) return next(err)
+    res.json(doc[0])
   })
 })
 
 // Returns Falcon 9 info
-v1.get("/falcon9", (req, res) => {
+v1.get("/falcon9", (req, res, next) => {
   global.db.collection("vehicle").find({"id": "falcon9"},{"_id": 0 }).toArray((err, doc) => {
-    if (err) return console.log(err)
-    res.end(JSON.stringify(doc[0], null, 2))
+    if (err) return next(err)
+    res.json(doc[0])
   })
 })
 
 // Returns Falcon Heavy info
-v1.get("/falconheavy", (req, res) => {
+v1.get("/falconheavy", (req, res, next) => {
   global.db.collection("vehicle").find({"id": "falcon_heavy"},{"_id": 0 }).toArray((err, doc) => {
-    if (err) return console.log(err)
-    res.end(JSON.stringify(doc[0], null, 2))
+    if (err) return next(err)
+    res.json(doc[0])
   })
 })
 
 // Returns Dragon info
-v1.get("/dragon", (req, res) => {
+v1.get("/dragon", (req, res, next) => {
   global.db.collection("vehicle").find({"id": "dragon"},{"_id": 0 }).toArray((err, doc) => {
-    if (err) return console.log(err)
-    res.end(JSON.stringify(doc[0], null, 2))
+    if (err) return next(err)
+    res.json(doc[0])
   })
 })
 

--- a/test/v1-all.test.js
+++ b/test/v1-all.test.js
@@ -1,7 +1,6 @@
 
 const app = require("../app")
 const request = require("supertest")
-const express = require("express")
 
 beforeAll((done) => {
   app.on("ready", () => {
@@ -161,8 +160,8 @@ test("It should return all past launches from LC-4E", () => {
 
 test("It should return no launches from made up launchpad", () => {
   return request(app).get("/v1/launches?site=vafb_slc_5e").then(response => {
-    expect(response.statusCode).toBe(404)
-    expect(response.text).toContain("No results found")
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toEqual([])
   })
 })
 
@@ -175,21 +174,22 @@ test("It should return all 2012 launches", () => {
 
 test("It should return no 2005 launches", () => {
   return request(app).get("/v1/launches?year=2005").then(response => {
-    expect(response.statusCode).toBe(404)
-    expect(response.text).toContain("No results found")
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toEqual([])
   })
 })
 
 test("It should return past launches in timeframe", () => {
   return request(app).get("/v1/launches?start=2011-01-20&final=2017-05-25").then(response => {
     expect(response.statusCode).toBe(200)
+    expect(response.body).not.toHaveLength(0)
   })
 })
 
 test("It should return no past launches in timeframe", () => {
   return request(app).get("/v1/launches?start=2005-01-20&final=2005-05-25").then(response => {
-    expect(response.statusCode).toBe(404)
-    expect(response.text).toContain("No results found")
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toEqual([])
   })
 })
 
@@ -202,8 +202,8 @@ test("It should return all launches with core B1021", () => {
 
 test("It should return no launches with core A1021", () => {
   return request(app).get("/v1/launches/cores/A1021").then(response => {
-    expect(response.statusCode).toBe(404)
-    expect(response.text).toContain("No results found")
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toEqual([])
   })
 })
 
@@ -216,8 +216,8 @@ test("It should return all launches with cap C106", () => {
 
 test("It should return no launches with cap C403", () => {
   return request(app).get("/v1/launches/caps/C403").then(response => {
-    expect(response.statusCode).toBe(404)
-    expect(response.text).toContain("No results found")
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toEqual([])
   })
 })
 
@@ -242,32 +242,35 @@ test("It should return all past RTLS launches", () => {
 test("It should return all upcoming launches", () => {
   return request(app).get("/v1/launches/upcoming").then(response => {
     expect(response.statusCode).toBe(200)
+    expect(response.body).not.toHaveLength(0)
   })
 })
 
 test("It should return all upcoming launches in 2017", () => {
   return request(app).get("/v1/launches/upcoming?year=2017").then(response => {
     expect(response.statusCode).toBe(200)
+    expect(response.body).not.toHaveLength(0)
   })
 })
 
 test("It should return no upcoming launches in 2016", () => {
   return request(app).get("/v1/launches/upcoming?year=2016").then(response => {
-    expect(response.statusCode).toBe(404)
-    expect(response.text).toContain("No results found")
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toEqual([])
   })
 })
 
 test("It should return all launches in the timeframe", () => {
   return request(app).get("/v1/launches/upcoming?start=2011-01-20&final=2055-05-25").then(response => {
     expect(response.statusCode).toBe(200)
+    expect(response.body).not.toHaveLength(0)
   })
 })
 
 test("It should return no launches in the timeframe", () => {
   return request(app).get("/v1/launches/upcoming?start=2011-01-20&final=2016-05-25").then(response => {
-    expect(response.statusCode).toBe(404)
-    expect(response.text).toContain("No results found")
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toEqual([])
   })
 })
 

--- a/test/v1-all.test.js
+++ b/test/v1-all.test.js
@@ -1,6 +1,7 @@
 
 const app = require("../app")
 const request = require("supertest")
+const express = require("express")
 
 beforeAll((done) => {
   app.on("ready", () => {
@@ -16,6 +17,31 @@ test("It should return 404 endpoint error", () => {
   return request(app).get("/v2").then(response => {
     expect(response.statusCode).toBe(404)
     expect(response.text).toContain("No results found")
+  })
+})
+
+//------------------------------------------------------------
+//                     500 Errors
+//------------------------------------------------------------
+
+test("It should return 500 error", () => {
+  // we add endpoint that throws error internally to the first router
+  // order is important here in order to not hit default 404 endpoint
+  for (let i = 0; i < app._router.stack.length; i++) {
+    let layer = app._router.stack[i]
+    if (layer.match("/v1") && layer.name == "router") {
+      layer.handle.get("/endpoint_that_errors", (req, res, next) => {
+        next(new Error("Forced error"))
+      })
+      break
+    }
+  }
+
+  return request(app).get("/v1/endpoint_that_errors").then((response) => {
+    expect(response.statusCode).toBe(500)
+    expect(response.body).toMatchObject({
+      error: "Internal Server Error"
+    })
   })
 })
 
@@ -90,7 +116,7 @@ test("It should return Dragon info", () => {
 test("It should return all launchpads", () => {
   return request(app).get("/v1/launchpads").then(response => {
     expect(response.statusCode).toBe(200)
-    expect(response.text.length).toBe(4368)
+    expect(response.text.length).toBe(3735)
   })
 })
 
@@ -103,7 +129,7 @@ test("It should return LC-39A info", () => {
 
 test("It should return no launchpads found info", () => {
   return request(app).get("/v1/launchpads/ksc_lc_40a").then(response => {
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(404)
     expect(response.text).toContain("No results found")
   })
 })
@@ -135,7 +161,7 @@ test("It should return all past launches from LC-4E", () => {
 
 test("It should return no launches from made up launchpad", () => {
   return request(app).get("/v1/launches?site=vafb_slc_5e").then(response => {
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(404)
     expect(response.text).toContain("No results found")
   })
 })
@@ -149,7 +175,7 @@ test("It should return all 2012 launches", () => {
 
 test("It should return no 2005 launches", () => {
   return request(app).get("/v1/launches?year=2005").then(response => {
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(404)
     expect(response.text).toContain("No results found")
   })
 })
@@ -162,7 +188,7 @@ test("It should return past launches in timeframe", () => {
 
 test("It should return no past launches in timeframe", () => {
   return request(app).get("/v1/launches?start=2005-01-20&final=2005-05-25").then(response => {
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(404)
     expect(response.text).toContain("No results found")
   })
 })
@@ -176,7 +202,7 @@ test("It should return all launches with core B1021", () => {
 
 test("It should return no launches with core A1021", () => {
   return request(app).get("/v1/launches/cores/A1021").then(response => {
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(404)
     expect(response.text).toContain("No results found")
   })
 })
@@ -190,7 +216,7 @@ test("It should return all launches with cap C106", () => {
 
 test("It should return no launches with cap C403", () => {
   return request(app).get("/v1/launches/caps/C403").then(response => {
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(404)
     expect(response.text).toContain("No results found")
   })
 })
@@ -227,20 +253,20 @@ test("It should return all upcoming launches in 2017", () => {
 
 test("It should return no upcoming launches in 2016", () => {
   return request(app).get("/v1/launches/upcoming?year=2016").then(response => {
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(404)
     expect(response.text).toContain("No results found")
   })
 })
 
 test("It should return all launches in the timeframe", () => {
-  return request(app).get("/v1/launches/upcoming?start=2011-01-20&final=2017-05-25").then(response => {
+  return request(app).get("/v1/launches/upcoming?start=2011-01-20&final=2055-05-25").then(response => {
     expect(response.statusCode).toBe(200)
   })
 })
 
 test("It should return no launches in the timeframe", () => {
   return request(app).get("/v1/launches/upcoming?start=2011-01-20&final=2016-05-25").then(response => {
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(404)
     expect(response.text).toContain("No results found")
   })
 })
@@ -266,7 +292,7 @@ test("It should return all info on C106", () => {
 
 test("It should return no info on C406", () => {
   return request(app).get("/v1/parts/caps/C406").then(response => {
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(404)
     expect(response.text).toContain("No results found")
   })
 })
@@ -288,7 +314,7 @@ test("It should return core info on B1021", () => {
 
 test("It should return no core info on A1021", () => {
   return request(app).get("/v1/parts/cores/A1021").then(response => {
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(404)
     expect(response.text).toContain("No results found")
   })
 })


### PR DESCRIPTION
Internal errors were not handled properly, just outputting `console.log` and allowing endpoint to continue processing would lead us to undefined state.

Error connecting to db would keep app running, but useless, better to die and let process manager attempt to restart us.

500 error test is a little bit hacky, but I prefer this way then having test logic mixed with production code.

Tests shouldn't be using `response.text` but `response.body` since it contains already parsed JSON object that we can better inspect then raw text. I will change few more tests to do it better.

Regarding statuses returned:
- If we return 200 status, we shouldn't return `error` in body but empty array.
- In case of listings or searches it's ok to return 200 with empty results.
- In case of specific capsule or core request by identifier, we should return 404 since it's client's fault that he's requesting single item that does not exist.