### PR TITLE
Add spacexlaunches.com to Apps

### DIFF
--- a/apps.md
+++ b/apps.md
@@ -8,6 +8,7 @@
 | [SpaceX Data.Info](http://spacexdata.info) | Website | [Charles Omer](https://www.charlesomer.co.uk) | N/A | [Zyndex](https://www.zyndex.co.uk) |
 | [SpaceX Wiki](https://www.spacexwiki.com/) | Website | [Chris Stielper](https://github.com/cstielper) | [GitHub](https://github.com/cstielper/react-spacex-wiki) |
 | [X-Watch](https://x-watch.xyz/) | Website | [Matt Mills](https://github.com/mattmillsxyz) | [GitHub](https://github.com/mattmillsxyz/x-watch) |
+| [SpaceXLaunches.com](https://spacexlaunches.com) | Website | [louisjc](https://github.com/louisjc/) | [GitHub](https://github.com/louisjc/spacexlaunches.com) |
 | [SpaceXPedia](https://itunes.apple.com/app/spacexpedia/id1434177600?mt=8) | iOS App | [Philip Engberg](https://github.com/philipengberg) | [GitHub](https://github.com/philipengberg/SpaceXPedia) |
 | [SpaceX Companion](https://play.google.com/store/apps/details?id=nl.studionoorderlicht.spacex) | Android App | [Jeroen Boumans](https://github.com/jeroenboumans) | Not open sourced yet | [Website](https://spacexcompanion.app)
 | [SpaceXLaunches](https://play.google.com/store/apps/details?id=com.danielscholte.spacexlaunches) | Android App | [Daniël Scholte](https://github.com/linuxfreak23) | Closed source |


### PR DESCRIPTION
Adding [spacexlaunches.com](http://spacexlaunches.com), built using the v3 api.