### PR TITLE
Update clients and contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ covered, make sure to add a test for it.
 
 1. Fork the repo, make changes, add tests, commit, and submit a Pull Request
 
-2. New Pull Requests will automatically trigger a Travis CI Build
+2. New Pull Requests will automatically trigger a CircleCI Build
 
-3. If the build fails, look at the [Build Logs](https://travis-ci.org/r-spacex/SpaceX-API).
+3. If the build fails, look at the [Build Logs](https://circleci.com/gh/r-spacex/SpaceX-API).
 Changes will not be merged unless the build passes
 
 4. If the build succeeds, the pull request will be merged, and automatically

--- a/clients.md
+++ b/clients.md
@@ -4,6 +4,7 @@
 
 |Name|Lang|Creator(s)|Repo|
 |:---|:---|:---|:---|
+| SpaceX-GraphQL | TypeScript | Jordan Owens | [GitHub](https://github.com/jor-dan/SpaceX-GraphQL) |
 | spacex-graphql-api | GraphQL | Emerson Laurentino | [GitHub](https://github.com/emersonlaurentino/spacex-qraphql-api) |
 | Oddity | .NET  | Tearth | [GitHub](https://github.com/Tearth/Oddity) |
 | SpaceX-API-Wrapper | Node.js | Thomas Smyth | [GitHub](https://github.com/Thomas-Smyth/SpaceX-API-Wrapper) |


### PR DESCRIPTION
Adds a new GraphQL wrapper. This one supports the v3 endpoints.

Also updates language in the contribution guide that still refers to Travis CI instead of CircleCI. 