### PR TITLE
Removing unused variable assignment

### DIFF
--- a/src/middleware/redis-cache.js
+++ b/src/middleware/redis-cache.js
@@ -203,6 +203,5 @@ module.exports = (opts = {}) => {
     } catch (e) {
       console.log('Failed to set cache');
     }
-    routeExpire = false;
   };
 };


### PR DESCRIPTION
The variable routeExpire is being assigned with its default value one more time without necessity.