### PR TITLE
Use cache more effectively in Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,28 @@
 
 FROM node:14-alpine
 
-WORKDIR /app
+LABEL maintainer="jakewmeyer@gmail.com"
 
-COPY package.json package-lock.json ./
+HEALTHCHECK --interval=10s --timeout=3s \
+  CMD curl --silent --fail http://localhost:6673/v4/admin/health || exit 1
+
+RUN apk add --no-cache --upgrade bash curl
+
+ENV NODE_ENV=production
+
+EXPOSE 6673
+
+# Run as an unprivileged user.
+RUN addgroup -S spacex && adduser -S -G spacex spacex 
+RUN mkdir /app && chown spacex /app
+USER spacex
+
+WORKDIR /app
+ENTRYPOINT ["/app/start.sh"]
+
+COPY package.json package-lock.json /app/
 
 RUN npm install --production
 
 COPY . .
 
-ENV NODE_ENV=production
-
-LABEL maintainer="jakewmeyer@gmail.com"
-
-EXPOSE 6673
-
-RUN apk add --no-cache --upgrade bash
-RUN apk --update add curl
-
-# Run as an unprivileged user.
-RUN addgroup -S spacex && adduser -S -G spacex spacex 
-USER spacex
-
-ENTRYPOINT ["./start.sh"]
-
-HEALTHCHECK --interval=10s --timeout=3s \
-  CMD curl --silent --fail http://localhost:6673/v4/admin/health || exit 1


### PR DESCRIPTION
Building the image repeatedly was consuming unnecessary disk space. Most of the changes are moving the lines up/down to make (probably) most frequent changed lines appear at the bottom to more utilize build cache.

This should have a noticeable effect on build times of consequent builds.

`npm install` is now run by a non-root user at the build time as well.

The changes shouldn't change the functionality. In the future, usage of Dockerfile supporting multistage builds may help reducing the image size, too.