### PR TITLE
/v4 is already written in BaseURL.

### DIFF
--- a/docs/v4/README.md
+++ b/docs/v4/README.md
@@ -63,7 +63,7 @@ Detailed info about SpaceX as a company
 Detailed info for serialized first stage cores
 
 - [Get all cores](cores/all.md) : `GET /cores`
-- [Get one core](cores/one.md) : `GET /v4/cores/:id`
+- [Get one core](cores/one.md) : `GET /cores/:id`
 - [Query cores](cores/query.md) : `POST /cores/query`
 - 🔒 [Create a core](cores/create.md) : `POST /cores`
 - 🔒 [Update a core](cores/update.md) : `PATCH /cores/:id`


### PR DESCRIPTION
Also, please refer to the [link](https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/cores/one.md)
The link should be the ``https://api.spacexdata.com/v4/cores/:id``