### PR TITLE
Fix links to the query document

### DIFF
--- a/docs/v4/capsules/query.md
+++ b/docs/v4/capsules/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries) guide for more details on building queries and paginating results.
+See [query](../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/v4/cores/query.md
+++ b/docs/v4/cores/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries) guide for more details on building queries and paginating results.
+See [query](../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/v4/crew/query.md
+++ b/docs/v4/crew/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries) guide for more details on building queries and paginating results.
+See [query](../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/v4/dragons/query.md
+++ b/docs/v4/dragons/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries) guide for more details on building queries and paginating results.
+See [query](../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/v4/landpads/query.md
+++ b/docs/v4/landpads/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries) guide for more details on building queries and paginating results.
+See [query](../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/v4/launches/query.md
+++ b/docs/v4/launches/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries) guide for more details on building queries and paginating results.
+See [query](../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/v4/launchpads/query.md
+++ b/docs/v4/launchpads/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries) guide for more details on building queries and paginating results.
+See [query](../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/v4/payloads/query.md
+++ b/docs/v4/payloads/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries) guide for more details on building queries and paginating results.
+See [query](../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/v4/rockets/query.md
+++ b/docs/v4/rockets/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries) guide for more details on building queries and paginating results.
+See [query](../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/v4/ships/query.md
+++ b/docs/v4/ships/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries) guide for more details on building queries and paginating results.
+See [query](../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/v4/starlink/query.md
+++ b/docs/v4/starlink/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries) guide for more details on building queries and paginating results.
+See [query](../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {


### PR DESCRIPTION
Links to the queries.md doc had missing extensions which led to 404 error.