### PR TITLE
perf: adjust jobs

### DIFF
--- a/jobs/cores.js
+++ b/jobs/cores.js
@@ -129,8 +129,9 @@ module.exports = async () => {
     logger.info('Lost cores updated');
 
     const reuseUpdates = cores.docs.map(async (core) => {
-      if (core?.id) {
-        const rtlsAttempts = await got.post(`${SPACEX_API}/launches/query`, {
+      if (!core?.id) return;
+      const [rtlsAttempts, rtlsLandings, asdsAttempts, asdsLandings] = Promise.all([
+        got.post(`${SPACEX_API}/launches/query`, {
           json: {
             query: {
               upcoming: false,
@@ -149,9 +150,8 @@ module.exports = async () => {
           resolveBodyOnly: true,
           responseType: 'json',
           throwHttpErrors: false,
-        });
-
-        const rtlsLandings = await got.post(`${SPACEX_API}/launches/query`, {
+        }),
+        got.post(`${SPACEX_API}/launches/query`, {
           json: {
             query: {
               upcoming: false,
@@ -171,9 +171,8 @@ module.exports = async () => {
           resolveBodyOnly: true,
           responseType: 'json',
           throwHttpErrors: false,
-        });
-
-        const asdsAttempts = await got.post(`${SPACEX_API}/launches/query`, {
+        }),
+        got.post(`${SPACEX_API}/launches/query`, {
           json: {
             query: {
               upcoming: false,
@@ -193,9 +192,8 @@ module.exports = async () => {
           resolveBodyOnly: true,
           responseType: 'json',
           throwHttpErrors: false,
-        });
-
-        const asdsLandings = await got.post(`${SPACEX_API}/launches/query`, {
+        }),
+        got.post(`${SPACEX_API}/launches/query`, {
           json: {
             query: {
               upcoming: false,
@@ -215,22 +213,23 @@ module.exports = async () => {
           resolveBodyOnly: true,
           responseType: 'json',
           throwHttpErrors: false,
-        });
-
-        await got.patch(`${SPACEX_API}/cores/${core.id}`, {
-          json: {
-            reuse_count: (core.launches.length > 0) ? core.launches.length - 1 : 0,
-            rtls_attempts: rtlsAttempts.totalDocs,
-            rtls_landings: rtlsLandings.totalDocs,
-            asds_attempts: asdsAttempts.totalDocs,
-            asds_landings: asdsLandings.totalDocs,
-          },
-          headers: {
-            'spacex-key': KEY,
-          },
-        });
-      }
+        }),
+      ]);
+      
+      await got.patch(`${SPACEX_API}/cores/${core.id}`, {
+        json: {
+          reuse_count: (core.launches.length > 0) ? core.launches.length - 1 : 0,
+          rtls_attempts: rtlsAttempts.totalDocs,
+          rtls_landings: rtlsLandings.totalDocs,
+          asds_attempts: asdsAttempts.totalDocs,
+          asds_landings: asdsLandings.totalDocs,
+        },
+        headers: {
+          'spacex-key': KEY,
+        },
+      });
     });
+
     await Promise.all(reuseUpdates);
     logger.info('Core reuse updated');
 

--- a/jobs/cores.js
+++ b/jobs/cores.js
@@ -215,7 +215,6 @@ module.exports = async () => {
           throwHttpErrors: false,
         }),
       ]);
-      
       await got.patch(`${SPACEX_API}/cores/${core.id}`, {
         json: {
           reuse_count: (core.launches.length > 0) ? core.launches.length - 1 : 0,

--- a/jobs/landpads.js
+++ b/jobs/landpads.js
@@ -22,46 +22,47 @@ module.exports = async () => {
     });
 
     const updates = landpads.docs.map(async (landpad) => {
-      const attempts = await got.post(`${SPACEX_API}/launches/query`, {
-        json: {
-          query: {
-            cores: {
-              $elemMatch: {
-                landpad: landpad.id,
-                landing_attempt: true,
+      const [attempts, successes] = await Promise.all([
+        got.post(`${SPACEX_API}/launches/query`, {
+          json: {
+            query: {
+              cores: {
+                $elemMatch: {
+                  landpad: landpad.id,
+                  landing_attempt: true,
+                },
               },
+              upcoming: false,
+              success: true,
             },
-            upcoming: false,
-            success: true,
+            options: {
+              pagination: false,
+            },
           },
-          options: {
-            pagination: false,
-          },
-        },
-        resolveBodyOnly: true,
-        responseType: 'json',
-      });
-
-      const successes = await got.post(`${SPACEX_API}/launches/query`, {
-        json: {
-          query: {
-            cores: {
-              $elemMatch: {
-                landpad: landpad.id,
-                landing_attempt: true,
-                landing_success: true,
+          resolveBodyOnly: true,
+          responseType: 'json',
+        }),
+        got.post(`${SPACEX_API}/launches/query`, {
+          json: {
+            query: {
+              cores: {
+                $elemMatch: {
+                  landpad: landpad.id,
+                  landing_attempt: true,
+                  landing_success: true,
+                },
               },
+              upcoming: false,
+              success: true,
             },
-            upcoming: false,
-            success: true,
+            options: {
+              pagination: false,
+            },
           },
-          options: {
-            pagination: false,
-          },
-        },
-        resolveBodyOnly: true,
-        responseType: 'json',
-      });
+          resolveBodyOnly: true,
+          responseType: 'json',
+        }),
+      ]);
 
       await got.patch(`${SPACEX_API}/landpads/${landpad.id}`, {
         json: {

--- a/jobs/launches.js
+++ b/jobs/launches.js
@@ -49,15 +49,12 @@ module.exports = async () => {
       responseType: 'json',
     });
 
-    const capsuleLaunches = capsules.docs.map(async (capsule) => {
-      const launchIds = launches.docs.filter((launch) => {
-        if (launch.capsules.includes(capsule.id)) {
-          return true;
-        }
-        return false;
-      }).map((launch) => launch.id);
+    const capsuleLaunches = capsules.docs.map((capsule) => {
+      const launchIds = launches.docs
+        .filter((launch) => launch.capsules.includes(capsule.id))
+        .map(({ id }) => id);
 
-      await got.patch(`${SPACEX_API}/capsules/${capsule.id}`, {
+      return got.patch(`${SPACEX_API}/capsules/${capsule.id}`, {
         json: {
           launches: launchIds,
         },
@@ -80,15 +77,12 @@ module.exports = async () => {
       responseType: 'json',
     });
 
-    const coreLaunches = cores.docs.map(async (core) => {
-      const launchIds = launches.docs.filter((launch) => {
-        if (launch.cores.filter((c) => c.core === core.id).length > 0) {
-          return true;
-        }
-        return false;
-      }).map((launch) => launch.id);
+    const coreLaunches = cores.docs.map((core) => {
+      const launchIds = launches.docs
+        .filter(({ cores }) => launch.cores.find((c) => c.core === core.id))
+        .map(({ id }) => id);
 
-      await got.patch(`${SPACEX_API}/cores/${core.id}`, {
+      return got.patch(`${SPACEX_API}/cores/${core.id}`, {
         json: {
           launches: launchIds,
         },
@@ -112,12 +106,9 @@ module.exports = async () => {
     });
 
     const crewLaunches = crewMembers.docs.map(async (crew) => {
-      const launchIds = launches.docs.filter((launch) => {
-        if (launch.crew.includes(crew.id)) {
-          return true;
-        }
-        return false;
-      }).map((launch) => launch.id);
+      const launchIds = launches.docs
+        .filter((launch) => launch.crew.includes(crew.id))
+        .map(({ id }) => id);
 
       await got.patch(`${SPACEX_API}/crew/${crew.id}`, {
         json: {
@@ -142,15 +133,12 @@ module.exports = async () => {
       responseType: 'json',
     });
 
-    const landpadLaunches = landpads.docs.map(async (landpad) => {
-      const launchIds = launches.docs.filter((launch) => {
-        if (launch.cores.filter((c) => c.landpad === landpad.id).length > 0) {
-          return true;
-        }
-        return false;
-      }).map((launch) => launch.id);
+    const landpadLaunches = landpads.docs.map((landpad) => {
+      const launchIds = launches.docs
+        .filter((launch) => launch.cores.find((c) => c.landpad === landpad.id))
+        .map(({ id }) => id);
 
-      await got.patch(`${SPACEX_API}/landpads/${landpad.id}`, {
+      return got.patch(`${SPACEX_API}/landpads/${landpad.id}`, {
         json: {
           launches: launchIds,
         },
@@ -173,15 +161,12 @@ module.exports = async () => {
       responseType: 'json',
     });
 
-    const launchpadLaunches = launchpads.docs.map(async (launchpad) => {
-      const launchIds = launches.docs.filter((launch) => {
-        if (launch.launchpad === launchpad.id) {
-          return true;
-        }
-        return false;
-      }).map((launch) => launch.id);
+    const launchpadLaunches = launchpads.docs.map((launchpad) => {
+      const launchIds = launches.docs
+        .filter((launch) => launch.launchpad === launchpad.id)
+        .map(({ id }) => id);
 
-      await got.patch(`${SPACEX_API}/launchpads/${launchpad.id}`, {
+      return got.patch(`${SPACEX_API}/launchpads/${launchpad.id}`, {
         json: {
           launches: launchIds,
         },
@@ -231,15 +216,12 @@ module.exports = async () => {
       responseType: 'json',
     });
 
-    const shipLaunches = ships.docs.map(async (ship) => {
-      const launchIds = launches.docs.filter((launch) => {
-        if (launch.ships.includes(ship.id)) {
-          return true;
-        }
-        return false;
-      }).map((launch) => launch.id);
+    const shipLaunches = ships.docs.map((ship) => {
+      const launchIds = launches.docs
+        .filter((launch) => launch.ships.includes(ship.id))
+        .map(({ id }) => id);
 
-      await got.patch(`${SPACEX_API}/ships/${ship.id}`, {
+      return got.patch(`${SPACEX_API}/ships/${ship.id}`, {
         json: {
           launches: launchIds,
         },

--- a/jobs/launches.js
+++ b/jobs/launches.js
@@ -49,12 +49,12 @@ module.exports = async () => {
       responseType: 'json',
     });
 
-    const capsuleLaunches = capsules.docs.map((capsule) => {
+    const capsuleLaunches = capsules.docs.map(async (capsule) => {
       const launchIds = launches.docs
         .filter((launch) => launch.capsules.includes(capsule.id))
         .map(({ id }) => id);
 
-      return got.patch(`${SPACEX_API}/capsules/${capsule.id}`, {
+      await got.patch(`${SPACEX_API}/capsules/${capsule.id}`, {
         json: {
           launches: launchIds,
         },
@@ -77,12 +77,12 @@ module.exports = async () => {
       responseType: 'json',
     });
 
-    const coreLaunches = cores.docs.map((core) => {
+    const coreLaunches = cores.docs.map(async (core) => {
       const launchIds = launches.docs
-        .filter(({ cores }) => launch.cores.find((c) => c.core === core.id))
+        .filter((launch) => launch.cores.find((c) => c.core === core.id))
         .map(({ id }) => id);
 
-      return got.patch(`${SPACEX_API}/cores/${core.id}`, {
+      await got.patch(`${SPACEX_API}/cores/${core.id}`, {
         json: {
           launches: launchIds,
         },
@@ -133,12 +133,12 @@ module.exports = async () => {
       responseType: 'json',
     });
 
-    const landpadLaunches = landpads.docs.map((landpad) => {
+    const landpadLaunches = landpads.docs.map(async (landpad) => {
       const launchIds = launches.docs
         .filter((launch) => launch.cores.find((c) => c.landpad === landpad.id))
         .map(({ id }) => id);
 
-      return got.patch(`${SPACEX_API}/landpads/${landpad.id}`, {
+      await got.patch(`${SPACEX_API}/landpads/${landpad.id}`, {
         json: {
           launches: launchIds,
         },
@@ -161,12 +161,12 @@ module.exports = async () => {
       responseType: 'json',
     });
 
-    const launchpadLaunches = launchpads.docs.map((launchpad) => {
+    const launchpadLaunches = launchpads.docs.map(async (launchpad) => {
       const launchIds = launches.docs
         .filter((launch) => launch.launchpad === launchpad.id)
         .map(({ id }) => id);
 
-      return got.patch(`${SPACEX_API}/launchpads/${launchpad.id}`, {
+      await got.patch(`${SPACEX_API}/launchpads/${launchpad.id}`, {
         json: {
           launches: launchIds,
         },
@@ -216,12 +216,12 @@ module.exports = async () => {
       responseType: 'json',
     });
 
-    const shipLaunches = ships.docs.map((ship) => {
+    const shipLaunches = ships.docs.map(async (ship) => {
       const launchIds = launches.docs
         .filter((launch) => launch.ships.includes(ship.id))
         .map(({ id }) => id);
 
-      return got.patch(`${SPACEX_API}/ships/${ship.id}`, {
+      await got.patch(`${SPACEX_API}/ships/${ship.id}`, {
         json: {
           launches: launchIds,
         },

--- a/jobs/launchpads.js
+++ b/jobs/launchpads.js
@@ -22,34 +22,35 @@ module.exports = async () => {
     });
 
     const updates = launchpads.docs.map(async (launchpad) => {
-      const attempts = await got.post(`${SPACEX_API}/launches/query`, {
-        json: {
-          query: {
-            launchpad: launchpad.id,
-            upcoming: false,
+      const [attempts, successes] = await Promise.all([
+        got.post(`${SPACEX_API}/launches/query`, {
+          json: {
+            query: {
+              launchpad: launchpad.id,
+              upcoming: false,
+            },
+            options: {
+              pagination: false,
+            },
           },
-          options: {
-            pagination: false,
+          resolveBodyOnly: true,
+          responseType: 'json',
+        }),
+        got.post(`${SPACEX_API}/launches/query`, {
+          json: {
+            query: {
+              launchpad: launchpad.id,
+              upcoming: false,
+              success: true,
+            },
+            options: {
+              pagination: false,
+            },
           },
-        },
-        resolveBodyOnly: true,
-        responseType: 'json',
-      });
-
-      const successes = await got.post(`${SPACEX_API}/launches/query`, {
-        json: {
-          query: {
-            launchpad: launchpad.id,
-            upcoming: false,
-            success: true,
-          },
-          options: {
-            pagination: false,
-          },
-        },
-        resolveBodyOnly: true,
-        responseType: 'json',
-      });
+          resolveBodyOnly: true,
+          responseType: 'json',
+        }),
+      ])
 
       await got.patch(`${SPACEX_API}/launchpads/${launchpad.id}`, {
         json: {

--- a/jobs/launchpads.js
+++ b/jobs/launchpads.js
@@ -50,7 +50,7 @@ module.exports = async () => {
           resolveBodyOnly: true,
           responseType: 'json',
         }),
-      ])
+      ]);
 
       await got.patch(`${SPACEX_API}/launchpads/${launchpad.id}`, {
         json: {

--- a/jobs/payloads.js
+++ b/jobs/payloads.js
@@ -30,7 +30,7 @@ module.exports = async () => {
           password: process.env.SPACEX_TRACK_PASSWORD,
         },
         cookieJar,
-      })
+      }),
     ]);
 
     // eslint-disable-next-line no-secrets/no-secrets

--- a/jobs/payloads.js
+++ b/jobs/payloads.js
@@ -12,26 +12,26 @@ const HEALTHCHECK = process.env.PAYLOADS_HEALTHCHECK;
  */
 module.exports = async () => {
   try {
-    const payloads = await got.post(`${SPACEX_API}/payloads/query`, {
-      json: {
-        query: {},
-        options: {
-          pagination: false,
-        },
-      },
-      resolveBodyOnly: true,
-      responseType: 'json',
-    });
-
     const cookieJar = new CookieJar();
-
-    await got.post('https://www.space-track.org/ajaxauth/login', {
-      form: {
-        identity: process.env.SPACEX_TRACK_LOGIN,
-        password: process.env.SPACEX_TRACK_PASSWORD,
-      },
-      cookieJar,
-    });
+    const [payloads] = await Promise.all([
+      got.post(`${SPACEX_API}/payloads/query`, {
+        json: {
+          query: {},
+          options: {
+            pagination: false,
+          },
+        },
+        resolveBodyOnly: true,
+        responseType: 'json',
+      }),
+      got.post('https://www.space-track.org/ajaxauth/login', {
+        form: {
+          identity: process.env.SPACEX_TRACK_LOGIN,
+          password: process.env.SPACEX_TRACK_PASSWORD,
+        },
+        cookieJar,
+      })
+    ]);
 
     // eslint-disable-next-line no-secrets/no-secrets
     const data = await got('https://www.space-track.org/basicspacedata/query/class/tle_latest/ORDINAL/1/orderby/NORAD_CAT_ID/epoch/>now-45/format/json', {


### PR DESCRIPTION
combine independent async operations under 'Promise.all'. Replace 'filter' to 'find' in order to avoid redundant iterations.