### PR TITLE
docs(clients): edit repo name

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -9,7 +9,7 @@ NOTE: Clients are grouped by API version(s) supported
 |Name|Lang|Creator(s)|Repo|
 |:---|:---|:---|:---|
 | Oddity | .NET  | Tearth | [GitHub](https://github.com/Tearth/Oddity) |
-| SpaceX-Async-Wrapper | Python | Ryu JuHeon | [GitHub](https://github.com/SaidBySolo/SpaceX-Async-Wrapper) |
+| SpaceXPy | Python | Ryu JuHeon | [GitHub](https://github.com/SaidBySolo/SpaceXPy) |
 | KSBSpacexKit | Swift | SaiBalaji K| [GitHub](https://github.com/SaiBalaji22/KSBSpacexKit) |
 | Marsy | C++ | AzuxDario | [GitHub](https://github.com/AzuxDario/Marsy) |
 | Spacex-api.js | Node.js | AkiaCode | [Github](https://github.com/AkiaCode/spacex-api.js) |


### PR DESCRIPTION
With the release of 2.0.0 this time, I changed the name of the repository as it supported Sync.

Thanks for taking the time!