### PR TITLE
Fix suffix in disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Open Source REST API for rocket, core, capsule, pad, and launch data
 
 <h4 align="center">
   <i>
-    We are not affiliated, associated, authorized, endorsed by, or in any way officially connected with Space Exploration Technologies Inc (SpaceX), or any of its subsidiaries or its affiliates. The names SpaceX as well as related names, marks, emblems and images are registered trademarks of their respective owners.
+    We are not affiliated, associated, authorized, endorsed by, or in any way officially connected with Space Exploration Technologies Corp (SpaceX), or any of its subsidiaries or its affiliates. The names SpaceX as well as related names, marks, emblems and images are registered trademarks of their respective owners.
   </i>
 </h4>
 


### PR DESCRIPTION
SpaceX is registered as Space Exploration Technologies Corp, not Space Exploration Technologies Inc.