### PR TITLE
Update relative paths to queries.md

### DIFF
--- a/docs/capsules/v4/query.md
+++ b/docs/capsules/v4/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries.md) guide for more details on building queries and paginating results.
+See [query](../../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/cores/v4/query.md
+++ b/docs/cores/v4/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries.md) guide for more details on building queries and paginating results.
+See [query](../../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/crew/v4/query.md
+++ b/docs/crew/v4/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries.md) guide for more details on building queries and paginating results.
+See [query](../../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/dragons/v4/query.md
+++ b/docs/dragons/v4/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries.md) guide for more details on building queries and paginating results.
+See [query](../../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/history/v4/query.md
+++ b/docs/history/v4/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries.md) guide for more details on building queries and paginating results.
+See [query](../../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/landpads/v4/query.md
+++ b/docs/landpads/v4/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries.md) guide for more details on building queries and paginating results.
+See [query](../../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/launches/v4/query.md
+++ b/docs/launches/v4/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries.md) guide for more details on building queries and paginating results.
+See [query](../../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {
@@ -31,9 +31,7 @@ See [query](../queries.md) guide for more details on building queries and pagina
         "reused": false,
         "recovery_attempt": true,
         "recovered": false,
-        "ships": [
-          "5ea6ed2e080df4000697c908"
-        ]
+        "ships": ["5ea6ed2e080df4000697c908"]
       },
       "links": {
         "patch": {
@@ -79,9 +77,7 @@ See [query](../queries.md) guide for more details on building queries and pagina
         "5ea6ed30080df4000697c913"
       ],
       "capsules": [],
-      "payloads": [
-        "5eb0e4c5b6c3bb0006eeb217"
-      ],
+      "payloads": ["5eb0e4c5b6c3bb0006eeb217"],
       "launchpad": "5e9e4502f509094188566f88",
       "auto_update": true,
       "flight_number": 50,

--- a/docs/launches/v5/query.md
+++ b/docs/launches/v5/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries.md) guide for more details on building queries and paginating results.
+See [query](../../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {
@@ -31,9 +31,7 @@ See [query](../queries.md) guide for more details on building queries and pagina
         "reused": false,
         "recovery_attempt": true,
         "recovered": false,
-        "ships": [
-          "5ea6ed2e080df4000697c908"
-        ]
+        "ships": ["5ea6ed2e080df4000697c908"]
       },
       "links": {
         "patch": {
@@ -79,9 +77,7 @@ See [query](../queries.md) guide for more details on building queries and pagina
         "5ea6ed30080df4000697c913"
       ],
       "capsules": [],
-      "payloads": [
-        "5eb0e4c5b6c3bb0006eeb217"
-      ],
+      "payloads": ["5eb0e4c5b6c3bb0006eeb217"],
       "launchpad": "5e9e4502f509094188566f88",
       "auto_update": true,
       "flight_number": 50,

--- a/docs/launchpads/v4/query.md
+++ b/docs/launchpads/v4/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries.md) guide for more details on building queries and paginating results.
+See [query](../../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/payloads/v4/query.md
+++ b/docs/payloads/v4/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries.md) guide for more details on building queries and paginating results.
+See [query](../../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/rockets/v4/query.md
+++ b/docs/rockets/v4/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries.md) guide for more details on building queries and paginating results.
+See [query](../../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/ships/v4/query.md
+++ b/docs/ships/v4/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries.md) guide for more details on building queries and paginating results.
+See [query](../../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {

--- a/docs/starlink/v4/query.md
+++ b/docs/starlink/v4/query.md
@@ -8,7 +8,7 @@
 
 **Body** :
 
-See [query](../queries.md) guide for more details on building queries and paginating results.
+See [query](../../queries.md) guide for more details on building queries and paginating results.
 
 ```json
 {


### PR DESCRIPTION
All the /docs/[route]/[version]/query.md files have a link to '../queries.md', which I believe is a holdover from before this [commit](https://github.com/r-spacex/SpaceX-API/commit/2015642a02a4572307ae2497d7df6d34681af282). This PR just updates all instances of '../queries.md' to '../../queries.md' so that the links work.