### PR TITLE
Updated Launch Library URL to 2.2.0

### DIFF
--- a/jobs/launch-library.js
+++ b/jobs/launch-library.js
@@ -8,7 +8,7 @@ const {
   LAUNCH_LIBRARY_HEALTHCHECK,
   SPACEX_API: API,
 } = process.env;
-const LAUNCH_LIBRARY_API = 'https://ll.thespacedevs.com/2.1.0/launch/upcoming';
+const LAUNCH_LIBRARY_API = 'https://ll.thespacedevs.com/2.2.0/launch/upcoming';
 
 /**
  * Attach Launch Library v2 launch id's to upcoming launches


### PR DESCRIPTION
Bumped LL2 URL in [/jobs/launch-library.js](https://github.com/r-spacex/SpaceX-API/blob/master/jobs/launch-library.js) to version 2.2.0 (latest).